### PR TITLE
fix(CSS) remove `position: relative`

### DIFF
--- a/addon/styles/mixins/_element.scss
+++ b/addon/styles/mixins/_element.scss
@@ -1,5 +1,4 @@
 @mixin element() {
-  position: relative;
   min-height: 1px;
   box-sizing: border-box;
 }

--- a/index.js
+++ b/index.js
@@ -5,12 +5,6 @@ var compileScssVariables = require('./lib/scss-variables-compiler');
 var getValidatedFlexiConfig = require('@html-next/flexi-config/lib/get-validated-flexi-config');
 var path = require('path');
 
-function assert(statement, test) {
-  if (!test) {
-    throw new Error(statement);
-  }
-}
-
 module.exports = {
   name: 'flexi-default-styles',
 


### PR DESCRIPTION
It is my understanding that `position: relative` is only needed for special cases. If people need it, they can add it to the element in question. Testing this change in my own app resulted in zero visual change, and a slightly smaller vendor.css.

This also facilitates the usage of ember-popper with flexi elements. As is, my tooltip addon is borked on the relatively positioned elements.

Eager to get this into 2.0.0 since it is a breaking change.